### PR TITLE
fix blurred sddm avatars

### DIFF
--- a/lookandfeel/contents/components/UserDelegate.qml
+++ b/lookandfeel/contents/components/UserDelegate.qml
@@ -54,9 +54,10 @@ Item {
         Image {
             id: face
             source: wrapper.avatarPath
-            sourceSize: Qt.size(faceSize, faceSize)
             fillMode: Image.PreserveAspectCrop
             anchors.fill: parent
+            mipmap: true
+            smooth: true
         }
 
         PlasmaCore.IconItem {


### PR DESCRIPTION
Removed sourceSize and replaced with mipmap and smooth.

sourceSize should not be assumed to be the same as the allowed size, as that introduces blur on off-sized images.